### PR TITLE
Fix Windows build

### DIFF
--- a/external/Swig.cmake
+++ b/external/Swig.cmake
@@ -28,14 +28,21 @@
 #             by FindSWIG.
 
 set(swig_path "${REPOSITORY_DIR}/external/common/src/swig-3.0.12.tar.gz")
+set(swigwin_path "${REPOSITORY_DIR}/external/common/src/swigwin-3.0.12.zip")
 set(pcre_path "${REPOSITORY_DIR}/external/common/src/pcre-8.37.tar.gz")
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  # We bundle pre-built Swig for Windows (presumably because we can't build it?)
-  add_custom_target(Swig)
-  set(swig_executable
-      ${PROJECT_SOURCE_DIR}/${PLATFORM}${BITNESS}${PLATFORM_SUFFIX}/bin/swig.exe)
-  set(swig_dir ${PROJECT_SOURCE_DIR}/common/share/swig/3.0.12)
+  ExternalProject_Add(
+    Swig
+    URL ${swigwin_path}
+    SOURCE_DIR "${EP_BASE}/Install/swig"
+    UPDATE_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
+  set(swig_executable ${EP_BASE}/Install/swig/swig.exe)
+  set(swig_dir ${EP_BASE}/Install/swig/Lib)  
 else()
   # Build Swig from source on non-Windows (e.g., Linux and OS X)
   ExternalProject_Add(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -643,11 +643,6 @@ if (NUPIC_BUILD_PYEXT_MODULES)
       -DSWIG_PYTHON_LEGACY_BOOL
       -I${SWIG_DIR}/python
       -I${SWIG_DIR}
-   # fix for swig python.swg not found on MinGW
-   # https://github.com/numenta/nupic.core/pull/1321#issuecomment-356665619
-   -python 
-   -I${SWIG_PATH}/Lib 
-   -I${SWIG_PATH}/Lib/python
       ${src_compiler_definitions}
   )
 


### PR DESCRIPTION
@breznak This PR adds windows support to swig 3.0.12 as an update to numenta/nupic.core#1321
Here is the build log:
- https://ci.appveyor.com/project/lscheinkman/nupic-core/build/job/fq7cop9ipp4929bf

CC: @rhyolight 